### PR TITLE
Fix #157

### DIFF
--- a/src/main/java/nc/tile/generator/TileFissionController.java
+++ b/src/main/java/nc/tile/generator/TileFissionController.java
@@ -75,12 +75,15 @@ public class TileFissionController extends TileItemGenerator {
 				consume();
 			}
 		}
-			tickStructureCheck();
-			checkStructure();
+		tickStructureCheck();
+		checkStructure();
+
 		if(!world.isRemote) {
 			tickRunCheck();
 			run();
-			overheat();
+			if (overheat() == true) {
+				return;
+			}
 			if (canProcess() && isPowered()) {
 				isGenerating = true;
 				time += getRateMultiplier();
@@ -155,10 +158,12 @@ public class TileFissionController extends TileItemGenerator {
 		return false;
 	}
 	
-	public void overheat() {
+	public boolean overheat() {
 		if (heat >= getMaxHeat() && NCConfig.fission_overheat) {
 			meltdown();
+			return true;
 		}
+		return false;
 	}
 	
 	public void meltdown() {


### PR DESCRIPTION
The TileFissionController replaces itself with lava when it has overheated. In that situation, we should bail early from the updateGenerator call since the block is gone.