### PR TITLE
Turbine now resets flow direction

### DIFF
--- a/src/main/java/nc/multiblock/turbine/Turbine.java
+++ b/src/main/java/nc/multiblock/turbine/Turbine.java
@@ -325,6 +325,7 @@ public class Turbine extends CuboidalMultiblockBase<TurbineUpdatePacket> {
 			return false;
 		}
 		
+		flowDir = null;
 		for (TileTurbineInlet inlet : inlets) {
 			BlockPos pos = inlet.getPos();
 			


### PR DESCRIPTION
When checking whether a turbine is valid or not, forget (yes, really) the last valid flow direction so that the user can create new flow directions