### PR TITLE
Add Radiation Player Decay Rate config option

### DIFF
--- a/src/main/java/nc/config/NCConfig.java
+++ b/src/main/java/nc/config/NCConfig.java
@@ -218,6 +218,7 @@ public class NCConfig {
 	public static String[] radiation_blocks_blacklist;
 	
 	public static double max_player_rads;
+	public static double radiation_player_decay_rate;
 	public static double radiation_spread_rate;
 	public static double radiation_decay_rate;
 	public static double radiation_lowest_rate;
@@ -643,6 +644,8 @@ public class NCConfig {
 		
 		Property propertyRadiationMaxPlayerRads = config.get(CATEGORY_RADIATION, "max_player_rads", 1000D, Lang.localise("gui.config.radiation.max_player_rads.comment"), 1D, 1000000000D);
 		propertyRadiationMaxPlayerRads.setLanguageKey("gui.config.radiation.max_player_rads");
+		Property propertyRadiationPlayerDecayRate = config.get(CATEGORY_RADIATION, "radiation_player_decay_rate", 0.05D, Lang.localise("gui.config.radiation.radiation_player_decay_rate.comment"), 0D, 1D);
+		propertyRadiationPlayerDecayRate.setLanguageKey("gui.config.radiation.radiation_player_decay_rate");
 		Property propertyRadiationSpreadRate = config.get(CATEGORY_RADIATION, "radiation_spread_rate", 0.1D, Lang.localise("gui.config.radiation.radiation_spread_rate.comment"), 0D, 1D);
 		propertyRadiationSpreadRate.setLanguageKey("gui.config.radiation.radiation_spread_rate");
 		Property propertyRadiationDecayRate = config.get(CATEGORY_RADIATION, "radiation_decay_rate", 0.001D, Lang.localise("gui.config.radiation.radiation_decay_rate.comment"), 0D, 1D);
@@ -961,6 +964,7 @@ public class NCConfig {
 		propertyOrderRadiation.add(propertyRadiationItemsBlacklist.getName());
 		propertyOrderRadiation.add(propertyRadiationBlocksBlacklist.getName());
 		propertyOrderRadiation.add(propertyRadiationMaxPlayerRads.getName());
+		propertyOrderRadiation.add(propertyRadiationPlayerDecayRate.getName());
 		propertyOrderRadiation.add(propertyRadiationSpreadRate.getName());
 		propertyOrderRadiation.add(propertyRadiationDecayRate.getName());
 		propertyOrderRadiation.add(propertyRadiationLowestRate.getName());
@@ -1194,6 +1198,7 @@ public class NCConfig {
 			radiation_blocks_blacklist = propertyRadiationBlocksBlacklist.getStringList();
 			
 			max_player_rads = propertyRadiationMaxPlayerRads.getDouble();
+			radiation_player_decay_rate = propertyRadiationPlayerDecayRate.getDouble();
 			radiation_spread_rate = propertyRadiationSpreadRate.getDouble();
 			radiation_decay_rate = propertyRadiationDecayRate.getDouble();
 			radiation_lowest_rate = propertyRadiationLowestRate.getDouble();
@@ -1431,6 +1436,7 @@ public class NCConfig {
 		propertyRadiationBlocksBlacklist.set(radiation_blocks_blacklist);
 		
 		propertyRadiationMaxPlayerRads.set(max_player_rads);
+		propertyRadiationPlayerDecayRate.set(radiation_player_decay_rate);
 		propertyRadiationSpreadRate.set(radiation_spread_rate);
 		propertyRadiationDecayRate.set(radiation_decay_rate);
 		propertyRadiationLowestRate.set(radiation_lowest_rate);

--- a/src/main/java/nc/radiation/RadiationHandler.java
+++ b/src/main/java/nc/radiation/RadiationHandler.java
@@ -83,6 +83,8 @@ public class RadiationHandler {
 				if (playerRads.getRadiationResistance() == 0D) playerRads.setRadXWoreOff(true);
 			}
 			else playerRads.setRadXWoreOff(false);
+
+			playerRads.setTotalRads(playerRads.getTotalRads() - NCConfig.radiation_player_decay_rate*PLAYER_TICK_RATE, false);
 			
 			if (playerRads.getRadawayBuffer() > 0D) {
 				playerRads.setTotalRads(playerRads.getTotalRads() - NCConfig.radiation_radaway_rate*PLAYER_TICK_RATE, false);

--- a/src/main/resources/assets/nuclearcraft/lang/en_us.lang
+++ b/src/main/resources/assets/nuclearcraft/lang/en_us.lang
@@ -2113,6 +2113,8 @@ gui.config.radiation.radiation_blocks_blacklist.comment=List of blocks that will
 
 gui.config.radiation.max_player_rads=Max Player Rads
 gui.config.radiation.max_player_rads.comment=The maximum number of rads a player can have before the radiation is fatal.
+gui.config.radiation.radiation_player_decay_rate=Player Radiation Decay Rate
+gui.config.radiation.radiation_player_decay_rate.comment=The rate at which radiation decreases in the player over time.
 gui.config.radiation.radiation_spread_rate=Radiation Spread Rate
 gui.config.radiation.radiation_spread_rate.comment=Controls the rate at which radiation will spread from chunk to chunk.
 gui.config.radiation.radiation_decay_rate=Radiation Decay Rate


### PR DESCRIPTION
Like I suggested in this issue https://github.com/turbodiesel4598/NuclearCraft/issues/448

I believe that the rad count of the player should naturally "decay" over time, as that seems realistic.
I have set the default value to be 0.05, feel free to change it.

Also note that setting the value to 0 would mean that no natural decay occurs.

Edit: After a few tests i have realised that 0.05 is way too high.