### PR TITLE
OpenTerrainGenerator Compatibility Fix

### DIFF
--- a/src/main/java/nc/Global.java
+++ b/src/main/java/nc/Global.java
@@ -6,7 +6,7 @@ public class Global {
 	public static final String MOD_SHORT_ID = "nc";
 	public static final String MOD_NAME = "NuclearCraft";
 	public static final String VERSION = "@VERSION@";
-	public static final String DEPENDENCIES = "after:tconstruct;after:conarm;";
+	public static final String DEPENDENCIES = "after:tconstruct;after:conarm;after:openterraingenerator";
 
 	public static final String NC_CLIENT_PROXY = "nc.proxy.ClientProxy";
 	public static final String NC_COMMON_PROXY = "nc.proxy.CommonProxy";

--- a/src/main/java/nc/NuclearCraft.java
+++ b/src/main/java/nc/NuclearCraft.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
 @Mod(modid = Global.MOD_ID, name = Global.MOD_NAME, version = Global.VERSION, dependencies = Global.DEPENDENCIES, guiFactory = Global.GUI_FACTORY)
@@ -48,5 +49,11 @@ public class NuclearCraft {
 	public void postInit(FMLPostInitializationEvent postEvent) {
 		NCUtil.getLogger().info("Post Initializing...");
 		proxy.postInit(postEvent);
+	}
+
+	@EventHandler
+	public void serverLoad(FMLServerStartingEvent event) {
+		NCUtil.getLogger().info("Server loading...");
+		proxy.serverLoad(event);
 	}
 }

--- a/src/main/java/nc/proxy/CommonProxy.java
+++ b/src/main/java/nc/proxy/CommonProxy.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import slimeknights.tconstruct.library.materials.Material;
@@ -125,11 +126,14 @@ public class CommonProxy {
 		MinecraftForge.EVENT_BUS.register(new RadiationCapabilityHandler());
 		MinecraftForge.EVENT_BUS.register(new RadiationHandler());
 		MinecraftForge.EVENT_BUS.register(new RadiationEnvironmentHandler());
-		RadBiomes.init();
-		
+
 		MinecraftForge.EVENT_BUS.register(new PlayerRespawnHandler());
 	}
-	
+
+	public void serverLoad(FMLServerStartingEvent event) {
+		RadBiomes.init();
+	}
+
 	// Packets
 	
 	public World getWorld(int dimensionId) {


### PR DESCRIPTION
OTG does biome registration during world load. As such, it was impossible for NuclearCraft to assign radiation to custom OTG biomes.

This change pushes the radiation init to the same phase, and ensures that NuclearCraft runs after OTG.