### PR TITLE
Make sure version selector complies with ForgeGradle requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ compileJava {
 }
 
 minecraft {
-	version = "${forge_version}"
+	version = "${mc_version}-${forge_version}"
 	runDir = "run"
 	replace "@VERSION@", "${mod_version}"
 	mappings = "snapshot_20171003"


### PR DESCRIPTION
When running setupDecompWorkspaces, I see this result:
> 
> ./gradlew setupDecompWorkspace
> FAILURE: Build failed with an exception.
> 
> * Where:
> Build file '/Users/dizzyd/src/NuclearCraft/build.gradle' line: 56
>
> * What went wrong:
> A problem occurred evaluating root project 'NuclearCraft'.
> > You must specify the full forge version, including MC version in your build.gradle. Example: 1.12.2-14.23.5.2811
>
> BUILD FAILED
>
> Total time: 6.553 secs

This patch fixes the problem by adding the version selector.