### PR TITLE
Add configurable support for rendering chunk boundaries

### DIFF
--- a/src/main/java/nc/client/ClientEventHandler.java
+++ b/src/main/java/nc/client/ClientEventHandler.java
@@ -1,0 +1,114 @@
+package nc.client;
+
+import nc.config.NCConfig;
+import nc.init.NCBlocks;
+import nc.tile.radiation.TileGeigerCounter;
+import nc.tile.radiation.TileRadiationScrubber;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.oredict.OreDictionary;
+import org.lwjgl.opengl.GL11;
+
+public class ClientEventHandler {
+
+    private ItemStack GEIGER_BLOCK_ITEM;
+    private ItemStack SCRUBBER_BLOCK_ITEM;
+
+    public ClientEventHandler() {
+        GEIGER_BLOCK_ITEM = new ItemStack(NCBlocks.geiger_block, 1);
+        SCRUBBER_BLOCK_ITEM = new ItemStack(NCBlocks.radiation_scrubber, 1);
+    }
+
+    @SubscribeEvent
+    public void onRenderWorldLastEvent(RenderWorldLastEvent event) {
+        //Overlay renderer for the geiger counter and radiation scrubber blocks
+        boolean chunkBorders = false;
+        Minecraft mc = Minecraft.getMinecraft();
+
+        // Bail fast if rendering is disabled
+        if (!NCConfig.render_chunk_boundaries) {
+            return;
+        }
+
+        // Draw the chunk borders if we're either holding a geiger block OR looking at one
+        for(EnumHand hand : EnumHand.values()) {
+            ItemStack heldItem = Minecraft.getMinecraft().player.getHeldItem(hand);
+
+            if (OreDictionary.itemMatches(GEIGER_BLOCK_ITEM, heldItem, true) ||
+                OreDictionary.itemMatches(SCRUBBER_BLOCK_ITEM, heldItem, true)) {
+                chunkBorders = true;
+                break;
+            }
+        }
+
+        TileEntity te = mc.world.getTileEntity(mc.objectMouseOver.getBlockPos());
+        if (!chunkBorders && mc.objectMouseOver != null && mc.objectMouseOver.typeOfHit == RayTraceResult.Type.BLOCK &&
+                (te instanceof TileGeigerCounter || (te instanceof TileRadiationScrubber))) {
+            chunkBorders = true;
+        }
+
+        //
+        // Logic/rendering below taken with minor changes from BluSunrize's Immersive Engineering mod
+        // github.com/BluSunrize/ImmersiveEngineering/../blusunrize/immersiveengineering/client/ClientEventHandler.java
+        //
+        if(chunkBorders)
+        {
+            EntityPlayer player = mc.player;
+            double px = TileEntityRendererDispatcher.staticPlayerX;
+            double py = TileEntityRendererDispatcher.staticPlayerY;
+            double pz = TileEntityRendererDispatcher.staticPlayerZ;
+            int chunkX = (int)player.posX >> 4<<4;
+            int chunkZ = (int)player.posZ >> 4<<4;
+            int y = Math.min((int)player.posY-2, player.getEntityWorld().getChunkFromChunkCoords(chunkX, chunkZ).getLowestHeight());
+            float h = (float)Math.max(32, player.posY-y+4);
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder BufferBuilder = tessellator.getBuffer();
+
+            GlStateManager.disableTexture2D();
+            GlStateManager.enableBlend();
+            GlStateManager.disableCull();
+            GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+            GlStateManager.shadeModel(GL11.GL_SMOOTH);
+            float r = 255;
+            float g = 0;
+            float b = 0;
+            BufferBuilder.setTranslation(chunkX-px, y+2-py, chunkZ-pz);
+            GlStateManager.glLineWidth(5f);
+            BufferBuilder.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION_COLOR);
+            BufferBuilder.pos(0, 0, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, h, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 0, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, h, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 0, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, h, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, 0, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, h, 16).color(r, g, b, .375f).endVertex();
+
+            BufferBuilder.pos(0, 2, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 2, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, 2, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, 2, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(0, 2, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 2, 16).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 2, 0).color(r, g, b, .375f).endVertex();
+            BufferBuilder.pos(16, 2, 16).color(r, g, b, .375f).endVertex();
+            tessellator.draw();
+            BufferBuilder.setTranslation(0, 0, 0);
+            GlStateManager.shadeModel(GL11.GL_FLAT);
+            GlStateManager.enableCull();
+            GlStateManager.disableBlend();
+            GlStateManager.enableTexture2D();
+        }
+    }
+}

--- a/src/main/java/nc/config/NCConfig.java
+++ b/src/main/java/nc/config/NCConfig.java
@@ -285,6 +285,8 @@ public class NCConfig {
 	
 	public static boolean ore_dict_priority_bool;
 	public static String[] ore_dict_priority;
+
+	public static boolean render_chunk_boundaries;
 	
 	public static void preInit() {
 		File configFile = new File(Loader.instance().getConfigDir(), "nuclearcraft.cfg");
@@ -759,6 +761,9 @@ public class NCConfig {
 		propertyOreDictPriorityBool.setLanguageKey("gui.config.other.ore_dict_priority_bool");
 		Property propertyOreDictPriority = config.get(CATEGORY_OTHER, "ore_dict_priority", new String[] {"minecraft", "thermalfoundation", "techreborn", "nuclearcraft", "immersiveengineering", "mekanism", "ic2", "appliedenergistics2", "refinedstorage", "actuallyadditions", "advancedRocketry", "thaumcraft", "biomesoplenty"}, Lang.localise("gui.config.other.ore_dict_priority.comment"));
 		propertyOreDictPriority.setLanguageKey("gui.config.other.ore_dict_priority");
+
+		Property propertyRenderChunkBoundariesBool = config.get(CATEGORY_OTHER, "render_chunk_boundaries", true, Lang.localise("gui.config.other.render_chunk_boundaries.comment"));
+		propertyRenderChunkBoundariesBool.setLanguageKey("gui.config.other.render_chunk_boundaries");
 		
 		List<String> propertyOrderOres = new ArrayList<String>();
 		propertyOrderOres.add(propertyOreDims.getName());
@@ -1014,6 +1019,7 @@ public class NCConfig {
 		propertyOrderOther.add(propertyRegisterCoFHFluids.getName());
 		propertyOrderOther.add(propertyOreDictPriorityBool.getName());
 		propertyOrderOther.add(propertyOreDictPriority.getName());
+		propertyOrderOther.add(propertyRenderChunkBoundariesBool.getName());
 		config.setCategoryPropertyOrder(CATEGORY_OTHER, propertyOrderOther);
 		
 		if (setFromConfig) {
@@ -1251,6 +1257,7 @@ public class NCConfig {
 			register_cofh_fluids = propertyRegisterCoFHFluids.getBoolean();
 			ore_dict_priority_bool = propertyOreDictPriorityBool.getBoolean();
 			ore_dict_priority = propertyOreDictPriority.getStringList();
+			render_chunk_boundaries = propertyRenderChunkBoundariesBool.getBoolean();
 		}
 		
 		propertyOreDims.set(ore_dims);
@@ -1487,6 +1494,7 @@ public class NCConfig {
 		propertyRegisterCoFHFluids.set(register_cofh_fluids);
 		propertyOreDictPriorityBool.set(ore_dict_priority_bool);
 		propertyOreDictPriority.set(ore_dict_priority);
+		propertyRenderChunkBoundariesBool.set(render_chunk_boundaries);
 		
 		if (setFromConfig) {
 			radiation_enabled_public = radiation_enabled;

--- a/src/main/java/nc/proxy/ClientProxy.java
+++ b/src/main/java/nc/proxy/ClientProxy.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import nc.Global;
 import nc.block.fluid.BlockFluidBase;
+import nc.client.ClientEventHandler;
 import nc.config.NCConfig;
 import nc.handler.TooltipHandler;
 import nc.init.NCArmor;
@@ -72,7 +73,10 @@ public class ClientProxy extends CommonProxy {
 
 	@Override
 	public void init(FMLInitializationEvent event) {
+
 		super.init(event);
+
+		MinecraftForge.EVENT_BUS.register(new ClientEventHandler());
 	}
 
 	@Override

--- a/src/main/resources/assets/nuclearcraft/lang/en_us.lang
+++ b/src/main/resources/assets/nuclearcraft/lang/en_us.lang
@@ -2235,6 +2235,8 @@ gui.config.other.ore_dict_priority_bool=Enable Ore Dict Mod Priority
 gui.config.other.ore_dict_priority_bool.comment=Will Ore Dictionary outputs be prioritised according to the mod list below? If false, the default Ore Dict entry will be used when deciding machine outputs.
 gui.config.other.ore_dict_priority=Ore Dict Mod Priority
 gui.config.other.ore_dict_priority.comment=Determines the priority of each mod's ore dictionary entries - earlier mods' IDs in this list have a higher priority. This is used to determine which mod's corresponding item is produced in machine recipes. If no matching mod is found, the default entry is used.
+gui.config.other.render_chunk_boundaries=Chunk boundaries visible
+gui.config.other.render_chunk_boundaries.comment=Show the chunk boundaries if you're holding/looking at a radiation scrubber or geiger counter block
 
 gui.computer.method_not_found=This method doesn't show in the archive maps - lost a method, you have... how embarassing... how embarassing! Gather round the GitHub repository, clear your mind, and find your missing method we will.
 gui.computer.invalid_method_number=Invalid method number


### PR DESCRIPTION
When holding or looking at a geiger counter or radiation scrubber block, render an overlay of the affected chunk. Configurable via GUI and config file.