### PR TITLE
Add support for dimensions that ignore biome background radiation settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 mc_version=1.12.2
-forge_version=1.12.2-14.23.5.2808
+forge_version=14.23.5.2808
 mod_version=2.13e
 
 ic2_version=2.8.108-ex112

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 mc_version=1.12.2
-forge_version=14.23.5.2808
+forge_version=1.12.2-14.23.5.2808
 mod_version=2.13e
 
 ic2_version=2.8.108-ex112

--- a/src/main/java/nc/config/NCConfig.java
+++ b/src/main/java/nc/config/NCConfig.java
@@ -209,6 +209,7 @@ public class NCConfig {
 	
 	public static String[] radiation_worlds;
 	public static String[] radiation_biomes;
+	public static String[] radiation_biome_exempt_worlds;
 	
 	public static String[] radiation_ores;
 	public static String[] radiation_items;
@@ -627,6 +628,8 @@ public class NCConfig {
 		propertyRadiationWorlds.setLanguageKey("gui.config.radiation.radiation_worlds");
 		Property propertyRadiationBiomes = config.get(CATEGORY_RADIATION, "radiation_biomes", new String[] {"nuclearcraft:nuclear_wasteland_0.25"}, Lang.localise("gui.config.radiation.radiation_biomes.comment"));
 		propertyRadiationBiomes.setLanguageKey("gui.config.radiation.radiation_biomes");
+		Property propertyRadiationBiomeExemptWorlds = config.get(CATEGORY_RADIATION, "radiation_biome_exempt_worlds", new String[] {"144"}, Lang.localise("gui.config.radiation.radiation_biome_exempt_worlds.comment"));
+		propertyRadiationBiomeExemptWorlds.setLanguageKey("gui.config.radiation.radiation_biome_exempt_worlds");
 		
 		Property propertyRadiationOres = config.get(CATEGORY_RADIATION, "radiation_ores", new String[] {"depletedFuelIC2U_" + (RadSources.URANIUM_238*4D + RadSources.PLUTONIUM_239/9D), "depletedFuelIC2MOX_" + (RadSources.PLUTONIUM_239*28D/9D)}, Lang.localise("gui.config.radiation.radiation_ores.comment"));
 		propertyRadiationOres.setLanguageKey("gui.config.radiation.radiation_ores");
@@ -954,6 +957,7 @@ public class NCConfig {
 		propertyOrderRadiation.add(propertyRadiationPlayerTickRate.getName());
 		propertyOrderRadiation.add(propertyRadiationWorlds.getName());
 		propertyOrderRadiation.add(propertyRadiationBiomes.getName());
+		propertyOrderRadiation.add(propertyRadiationBiomeExemptWorlds.getName());
 		propertyOrderRadiation.add(propertyRadiationOres.getName());
 		propertyOrderRadiation.add(propertyRadiationItems.getName());
 		propertyOrderRadiation.add(propertyRadiationBlocks.getName());
@@ -1185,6 +1189,7 @@ public class NCConfig {
 			
 			radiation_worlds = propertyRadiationWorlds.getStringList();
 			radiation_biomes = propertyRadiationBiomes.getStringList();
+			radiation_biome_exempt_worlds = propertyRadiationBiomeExemptWorlds.getStringList();
 			
 			radiation_ores = propertyRadiationOres.getStringList();
 			radiation_items = propertyRadiationItems.getStringList();
@@ -1422,6 +1427,7 @@ public class NCConfig {
 		
 		propertyRadiationWorlds.set(radiation_worlds);
 		propertyRadiationBiomes.set(radiation_biomes);
+		propertyRadiationBiomeExemptWorlds.set(radiation_biome_exempt_worlds);
 		
 		propertyRadiationOres.set(radiation_ores);
 		propertyRadiationItems.set(radiation_items);

--- a/src/main/java/nc/radiation/RadWorlds.java
+++ b/src/main/java/nc/radiation/RadWorlds.java
@@ -1,6 +1,7 @@
 package nc.radiation;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import nc.config.NCConfig;
@@ -8,12 +9,17 @@ import nc.config.NCConfig;
 public class RadWorlds {
 	
 	public static final Map<Integer, Double> BACKGROUND_MAP = new HashMap<Integer, Double>();
+	public static final HashSet<Integer> BIOME_BACKGROUND_EXEMPT_SET = new HashSet<Integer>();
 	
 	public static void init() {
 		for (String world : NCConfig.radiation_worlds) {
 			int scorePos = world.indexOf('_');
 			if (scorePos == -1) continue;
 			BACKGROUND_MAP.put(Integer.parseInt(world.substring(0, scorePos)), Double.parseDouble(world.substring(scorePos + 1)));
+		}
+
+		for (String world : NCConfig.radiation_biome_exempt_worlds) {
+			BIOME_BACKGROUND_EXEMPT_SET.add(Integer.parseInt(world));
 		}
 	}
 }

--- a/src/main/java/nc/radiation/RadiationHandler.java
+++ b/src/main/java/nc/radiation/RadiationHandler.java
@@ -70,11 +70,8 @@ public class RadiationHandler {
 			if (previousImmunityTime > 0D) {
 				playerRads.setRadiationImmunityTime(previousImmunityTime - PLAYER_TICK_RATE);
 			}
-			
-			double radiationLevel = RadiationHelper.transferRadsToPlayer(player.world, player, playerRads, PLAYER_TICK_RATE) +
-									RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE) +
-									RadiationHelper.transferRadsFromInventoryToPlayer(player, playerRads, chunk, PLAYER_TICK_RATE);
 
+			double radiationLevel = RadiationHelper.transferRadsToPlayer(player.world, player, playerRads, PLAYER_TICK_RATE) /*+ RadiationHelper.transferBackgroundRadsToPlayer(player.world.getBiome(player.getPosition()), player, playerRads, PLAYER_TICK_RATE)*/ + RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE) + RadiationHelper.transferRadsFromInventoryToPlayer(player, playerRads, chunk, PLAYER_TICK_RATE);
 			playerRads.setRadiationLevel(radiationLevel);
 			
 			if (!player.isCreative() && playerRads.isFatal()) player.attackEntityFrom(FATAL_RADS, Float.MAX_VALUE);

--- a/src/main/java/nc/radiation/RadiationHandler.java
+++ b/src/main/java/nc/radiation/RadiationHandler.java
@@ -75,10 +75,6 @@ public class RadiationHandler {
 									RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE) +
 									RadiationHelper.transferRadsFromInventoryToPlayer(player, playerRads, chunk, PLAYER_TICK_RATE);
 
-			if (!RadWorlds.BIOME_BACKGROUND_EXEMPT_SET.contains(player.world.provider.getDimension())) {
-				radiationLevel += RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE);
-			}
-
 			playerRads.setRadiationLevel(radiationLevel);
 			
 			if (!player.isCreative() && playerRads.isFatal()) player.attackEntityFrom(FATAL_RADS, Float.MAX_VALUE);

--- a/src/main/java/nc/radiation/RadiationHandler.java
+++ b/src/main/java/nc/radiation/RadiationHandler.java
@@ -71,7 +71,14 @@ public class RadiationHandler {
 				playerRads.setRadiationImmunityTime(previousImmunityTime - PLAYER_TICK_RATE);
 			}
 			
-			double radiationLevel = RadiationHelper.transferRadsToPlayer(player.world, player, playerRads, PLAYER_TICK_RATE) /*+ RadiationHelper.transferBackgroundRadsToPlayer(player.world.getBiome(player.getPosition()), player, playerRads, PLAYER_TICK_RATE)*/ + RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE) + RadiationHelper.transferRadsFromInventoryToPlayer(player, playerRads, chunk, PLAYER_TICK_RATE);
+			double radiationLevel = RadiationHelper.transferRadsToPlayer(player.world, player, playerRads, PLAYER_TICK_RATE) +
+									RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE) +
+									RadiationHelper.transferRadsFromInventoryToPlayer(player, playerRads, chunk, PLAYER_TICK_RATE);
+
+			if (!RadWorlds.BIOME_BACKGROUND_EXEMPT_SET.contains(player.world.provider.getDimension())) {
+				radiationLevel += RadiationHelper.transferRadsToPlayer(chunk, player, playerRads, PLAYER_TICK_RATE);
+			}
+
 			playerRads.setRadiationLevel(radiationLevel);
 			
 			if (!player.isCreative() && playerRads.isFatal()) player.attackEntityFrom(FATAL_RADS, Float.MAX_VALUE);
@@ -161,9 +168,11 @@ public class RadiationHandler {
 			if (chunk == null || !chunk.hasCapability(IRadiationSource.CAPABILITY_RADIATION_SOURCE, null)) return;
 			IRadiationSource chunkRadiation = chunk.getCapability(IRadiationSource.CAPABILITY_RADIATION_SOURCE, null);
 			if (chunkRadiation == null) return;
-			
-			Double biomeRadiation = RadBiomes.BIOME_MAP.get(chunk.getBiome(new BlockPos(8, 8, 8), biomeProvider));
-			if (biomeRadiation != null) RadiationHelper.addToChunkBuffer(chunkRadiation, biomeRadiation);
+
+			if (!RadWorlds.BIOME_BACKGROUND_EXEMPT_SET.contains(chunk.getWorld().provider.getDimension())) {
+				Double biomeRadiation = RadBiomes.BIOME_MAP.get(chunk.getBiome(new BlockPos(8, 8, 8), biomeProvider));
+				if (biomeRadiation != null) RadiationHelper.addToChunkBuffer(chunkRadiation, biomeRadiation);
+			}
 		}
 		
 		for (TileEntity tile : tileSet) {

--- a/src/main/resources/assets/nuclearcraft/lang/en_us.lang
+++ b/src/main/resources/assets/nuclearcraft/lang/en_us.lang
@@ -2096,6 +2096,8 @@ gui.config.radiation.radiation_worlds=World Background Radiation
 gui.config.radiation.radiation_worlds.comment=List of dimensions and their background radiation levels. Format: 'modid:dimID_radiationLevel'.
 gui.config.radiation.radiation_biomes=Biome Background Radiation
 gui.config.radiation.radiation_biomes.comment=List of biomes and their background radiation levels. These values stack with the underlying world's background radiation. Format: 'modid:biomeName_radiationLevel'.
+gui.config.radiation.radiation_biome_exempt_worlds=Worlds Without Biome Background Radiation
+gui.config.radiation.radiation_biome_exempt_worlds.comment=List of dimensions that should ignore biome background radiation settings.
 
 gui.config.radiation.radiation_ores=Ore Stack Radiation
 gui.config.radiation.radiation_ores.comment=List of ore dict entries and their stack radiation levels. Can be used to overwrite default values. Format: 'oreName_radiationLevel'.


### PR DESCRIPTION
This change is intended to support mods such as Compact Machines that use biomes that would normally only show up in other dimensions. If those biomes have background radiation settings, it may unintentionally cause the mod dimension to have radiation that you didn't want there.

The change adds a new config option with supporting logic to store and use a list of dimension IDs as biome-radiation exempt. The default value is the ID for the Compact Machines dimension, as it is the one I was aware of having this problem.