### PR TITLE
Fix active coolers not being recognized when run on the OpenJ9 VM

### DIFF
--- a/src/main/java/nc/tile/generator/TileFissionController.java
+++ b/src/main/java/nc/tile/generator/TileFissionController.java
@@ -787,7 +787,7 @@ public class TileFissionController extends TileItemGenerator implements IGui<Fis
 								double currentHeat = heat + (isProcessing ? heatThisTick : 0) + coolerHeatThisTick;
 								boolean isInValidPosition = false;
 								for (int i = 1; i < CoolerType.values().length; i++) {
-									if (tank.getFluidName() == CoolerType.values()[i].getFluidName()) {
+									if (tank.getFluidName().equals(CoolerType.values()[i].getFluidName())) {
 										if (coolerRequirements(x, y, z, i)) {
 											coolerHeatThisTick -= NCConfig.fission_active_cooling_rate[i - 1]*NCConfig.active_cooler_max_rate/20;
 											isInValidPosition = true;
@@ -907,7 +907,7 @@ public class TileFissionController extends TileItemGenerator implements IGui<Fis
 								double currentHeat = heat + (isProcessing ? heatThisTick : 0) + coolerHeatThisTick;
 								boolean isInValidPosition = false;
 								for (int i = 1; i < CoolerType.values().length; i++) {
-									if (tank.getFluidName() == CoolerType.values()[i].getFluidName()) {
+									if (tank.getFluidName().equals(CoolerType.values()[i].getFluidName())) {
 										if (coolerRequirements(x, y, z, i)) {
 											coolerHeatThisTick -= NCConfig.fission_active_cooling_rate[i - 1]*NCConfig.active_cooler_max_rate/20;
 											isInValidPosition = true;

--- a/src/main/java/nc/tile/generator/TileFusionCore.java
+++ b/src/main/java/nc/tile/generator/TileFusionCore.java
@@ -429,7 +429,7 @@ public class TileFusionCore extends TileFluidGenerator implements IGui<FusionUpd
 				int fluidAmount = Math.min(tank.getFluidAmount(), (4*NCConfig.machine_update_rate*NCConfig.active_cooler_max_rate)/20);
 				if (currentHeat > ROOM_TEMP) {
 					double cool_mult = posList.contains(getOpposite(pos)) ? NCConfig.fusion_heat_generation*4 : NCConfig.fusion_heat_generation;
-					for (int i = 1; i < CoolerType.values().length; i++) if (tank.getFluidName() == CoolerType.values()[i].getFluidName()) {
+					for (int i = 1; i < CoolerType.values().length; i++) if (tank.getFluidName().equals(CoolerType.values()[i].getFluidName())) {
 						cooled += (NCConfig.fusion_active_cooling_rate[i - 1]*fluidAmount*cool_mult)/(size*1000D);
 						break;
 					}


### PR DESCRIPTION
This was caused by comparing fluid name strings with ==, which only works if they share the same memory location