### PR TITLE
(NC:O) fix recipe map acquisition depending on GT version

### DIFF
--- a/src/main/java/nc/integration/gtce/GTCERecipeHelper.java
+++ b/src/main/java/nc/integration/gtce/GTCERecipeHelper.java
@@ -4,6 +4,7 @@ import static nc.config.NCConfig.gtce_recipe_logging;
 
 import java.util.*;
 
+import net.minecraftforge.fml.common.Loader;
 import org.apache.commons.lang3.tuple.Pair;
 
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
@@ -18,7 +19,15 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Optional;
 
 public class GTCERecipeHelper {
-	
+
+	private static RecipeMap<?> EXTRACTOR_MAP;
+
+	@Optional.Method(modid = "gregtech")
+	public static void checkGtVersion() {
+		String version = Loader.instance().getIndexedModList().get("gregtech").getVersion();
+		EXTRACTOR_MAP = getExtractorMap(Integer.parseInt(version.split("\\.")[0]));
+	}
+
 	// Thanks so much to Firew0lf for the original method!
 	@Optional.Method(modid = "gregtech")
 	public static void addGTCERecipe(String recipeName, BasicRecipe recipe) {
@@ -47,8 +56,9 @@ public class GTCERecipeHelper {
 				builder = addStats(recipeMap.recipeBuilder(), recipe, 30, 10);
 				break;
 			case "melter":
-				recipeMap = RecipeMaps.FLUID_EXTRACTION_RECIPES;
-				builder = addStats(recipeMap.recipeBuilder(), recipe, 32, 16);
+				recipeMap = EXTRACTOR_MAP;
+				if (recipeMap != null)
+				    builder = addStats(recipeMap.recipeBuilder(), recipe, 32, 16);
 				break;
 			case "supercooler":
 				recipeMap = RecipeMaps.VACUUM_RECIPES;
@@ -93,8 +103,9 @@ public class GTCERecipeHelper {
 				builder = addStats(recipeMap.recipeBuilder(), recipe, 20, 20).notConsumable(new IntCircuitIngredient(2));
 				break;
 			case "extractor":
-				recipeMap = RecipeMaps.FLUID_EXTRACTION_RECIPES;
-				builder = addStats(recipeMap.recipeBuilder(), recipe, 16, 12);
+				recipeMap = EXTRACTOR_MAP;
+				if (recipeMap != null)
+				    builder = addStats(recipeMap.recipeBuilder(), recipe, 16, 12);
 				break;
 			case "centrifuge":
 				recipeMap = RecipeMaps.CENTRIFUGE_RECIPES;
@@ -337,5 +348,17 @@ public class GTCERecipeHelper {
 			}
 		}
 		return MetaItems.SHAPE_MOLD_BALL;
+	}
+
+	@Optional.Method(modid = "gregtech")
+	private static RecipeMap<?> getExtractorMap(int gtVersion) {
+		if (gtVersion == 2) {
+			return RecipeMaps.EXTRACTOR_RECIPES;
+		} else {
+			try {
+				return (RecipeMap<?>) RecipeMaps.class.getField("FLUID_EXTRACTION_RECIPES").get(null);
+			} catch (NoSuchFieldException | IllegalAccessException ignored) {}
+		}
+		return null;
 	}
 }

--- a/src/main/java/nc/recipe/BasicRecipeHandler.java
+++ b/src/main/java/nc/recipe/BasicRecipeHandler.java
@@ -68,6 +68,7 @@ public abstract class BasicRecipeHandler extends AbstractRecipeHandler<BasicReci
 	
 	public void addGTCERecipes() {
 		if (ModCheck.gregtechLoaded() && GTCE_INTEGRATION.getBoolean(name)) {
+			GTCERecipeHelper.checkGtVersion();
 			for (BasicRecipe recipe : recipeList) {
 				GTCERecipeHelper.addGTCERecipe(name, recipe);
 			}


### PR DESCRIPTION
This PR fixes a crash caused by using the `FLUID_EXTRACTION_RECIPES` RecipeMap from GTCE when GTCEu is used instead. This is because that RecipeMap was removed and merged into the normal `EXTRACTOR_RECIPES` map.

Since the mod-id is unchanged, the easiest way to tell which version of GregTech is being used is the version of the Mod Container, since GTCEu bumped major version. We will not bump that again, so there is no worry of this breaking again in the future.

I decided to acquire the original GTCE map via reflection to avoid a potential compile error if CEu is ever used in the development environment. As a result I cache that Map since reflecting the same field many times for all of NC's compat is an unnecessary loss of launch-time performance.

I will be cherry-picking this commit back to NC as well, since the code is the same, it also has this issue.