### PR TITLE
[Underhal] GTCEu 2.4 compatibility

### DIFF
--- a/src/main/java/nc/integration/gtce/GTCERecipeHelper.java
+++ b/src/main/java/nc/integration/gtce/GTCERecipeHelper.java
@@ -1,12 +1,18 @@
 package nc.integration.gtce;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import org.apache.commons.lang3.tuple.Pair;
 
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
@@ -35,13 +41,63 @@ import net.minecraftforge.fml.common.Optional;
 public class GTCERecipeHelper {
 
 	private static RecipeMap<?> EXTRACTOR_MAP;
+	private static boolean isCEu = false;
+	private static Constructor<?> circuitConstructor;
+	private static Class<?> rb;
+	private static Method notConsumable;
+	private static Method acceptsStack;
+	private static Method acceptsFluid;
 
 	@Optional.Method(modid = "gregtech")
-	public static void checkGtVersion() {
-		String version = Loader.instance().getIndexedModList().get("gregtech").getVersion();
-		EXTRACTOR_MAP = getExtractorMap(Integer.parseInt(version.split("\\.")[0]));
+	public static void checkGtVersion()
+	{
+		String version = Loader.instance().getIndexedModList().get( "gregtech" ).getVersion();
+		int v = Integer.parseInt( version.split( "\\." )[0] );
+		try
+		{
+			if( v >= 2 )
+			{
+				isCEu = true;
+				circuitConstructor = ReflectionHelper.getClass( Launch.classLoader, "gregtech.api.recipes.ingredients.IntCircuitIngredient" ).getConstructor( int.class );
+				Class<? super Object> gtri = ReflectionHelper.getClass( Launch.classLoader, "gregtech.api.recipes.ingredients.GTRecipeInput" );
+				rb = ReflectionHelper.getClass( Launch.classLoader, "gregtech.api.recipes.RecipeBuilder" );
+				notConsumable = rb.getDeclaredMethod( "notConsumable", gtri );
+				acceptsStack = gtri.getDeclaredMethod( "acceptsStack", ItemStack.class );
+				acceptsFluid = gtri.getDeclaredMethod( "acceptsFluid", FluidStack.class );
+			}
+			else
+			{
+				notConsumable = rb.getDeclaredMethod( "notConsumable", Ingredient.class );
+			}
+		}
+		catch( NoSuchMethodException e )
+		{
+			throw new RuntimeException( e );
+		}
+		EXTRACTOR_MAP = getExtractorMap( isCEu );
 	}
-	
+
+	private static void notConsumableCEorCEuCircuit( RecipeBuilder<?> builder, int i )
+	{
+		IntCircuitIngredient ingredient;
+		try
+		{
+			if( isCEu )
+			{
+				ingredient = (IntCircuitIngredient) circuitConstructor.newInstance( i );
+			}
+			else
+			{
+				ingredient = new IntCircuitIngredient( i );
+			}
+			notConsumable.invoke( builder, ingredient );
+		}
+		catch( IllegalAccessException | InvocationTargetException | InstantiationException e )
+		{
+			throw new RuntimeException( e );
+		}
+	}
+
 	// Thanks so much to Firew0lf for the original method!
 	@Optional.Method(modid = "gregtech")
 	public static void addGTCERecipe(String recipeName, ProcessorRecipe recipe) {
@@ -93,7 +149,8 @@ public class GTCERecipeHelper {
 		case "pressurizer":
 			if (isPlateRecipe(recipe)) {
 				recipeMap = RecipeMaps.BENDER_RECIPES;
-				builder = addStats(recipeMap.recipeBuilder(), recipe, 24, 10).notConsumable(new IntCircuitIngredient(0));
+				builder = addStats(recipeMap.recipeBuilder(), recipe, 24, 10);
+				notConsumableCEorCEuCircuit( builder, isCEu ? 1 : 0 );
 			}
 			else {
 				recipeMap = RecipeMaps.COMPRESSOR_RECIPES;
@@ -110,11 +167,13 @@ public class GTCERecipeHelper {
 			break;
 		case "crystallizer":
 			recipeMap = RecipeMaps.CHEMICAL_RECIPES;
-			builder = addStats(recipeMap.recipeBuilder(), recipe, 30, 10).notConsumable(new IntCircuitIngredient(0));
+			builder = addStats(recipeMap.recipeBuilder(), recipe, 30, 10);
+			notConsumableCEorCEuCircuit( builder, 0 );
 			break;
 		case "dissolver":
 			recipeMap = RecipeMaps.CHEMICAL_RECIPES;
-			builder = addStats(recipeMap.recipeBuilder(), recipe, 20, 20).notConsumable(new IntCircuitIngredient(1));
+			builder = addStats(recipeMap.recipeBuilder(), recipe, 20, 20);
+			notConsumableCEorCEuCircuit( builder, 1 );
 			break;
 		case "extractor":
 			recipeMap = EXTRACTOR_MAP;
@@ -123,7 +182,8 @@ public class GTCERecipeHelper {
 			break;
 		case "centrifuge":
 			recipeMap = RecipeMaps.CENTRIFUGE_RECIPES;
-			builder = addStats(recipeMap.recipeBuilder(), recipe, 16, 80).notConsumable(new IntCircuitIngredient(0));
+			builder = addStats(recipeMap.recipeBuilder(), recipe, 16, 80);
+			notConsumableCEorCEuCircuit( builder, 0 );
 			break;
 		case "rock_crusher":
 			recipeMap = RecipeMaps.MACERATOR_RECIPES;
@@ -302,24 +362,70 @@ public class GTCERecipeHelper {
 	}
 	
 	@Optional.Method(modid = "gregtech")
-	private static boolean isRecipeConflict(Recipe recipe, List<ItemStack> inputs, List<FluidStack> fluidInputs) {
-		itemLoop: for (ItemStack input : inputs) {
-			for (CountableIngredient ingredient : recipe.getInputs()) {
-				if (ingredient.getIngredient().apply(input)) {
-					continue itemLoop;
+	private static boolean isRecipeConflict(Recipe recipe, List<ItemStack> inputs, List<FluidStack> fluidInputs)
+	{
+		if( !isCEu )
+		{
+			itemLoop:
+			for( ItemStack input : inputs )
+			{
+				for( CountableIngredient ingredient : recipe.getInputs() )
+				{
+					if( ingredient.getIngredient().apply( input ) )
+					{
+						continue itemLoop;
+					}
 				}
+				return false;
 			}
-			return false;
-		}
-		fluidLoop: for (FluidStack input : fluidInputs) {
-			for (FluidStack fluid : recipe.getFluidInputs()) {
-				if (input.isFluidEqual(fluid)) {
-					continue fluidLoop;
+			fluidLoop:
+			for( FluidStack input : fluidInputs )
+			{
+				for( FluidStack fluid : recipe.getFluidInputs() )
+				{
+					if( input.isFluidEqual( fluid ) )
+					{
+						continue fluidLoop;
+					}
 				}
+				return false;
 			}
-			return false;
+			return true;
 		}
-		return true;
+		else
+		{
+			try {
+				itemLoop:
+				for( ItemStack input : inputs )
+				{
+					for( Object ingredient : recipe.getInputs() )
+					{
+						if( acceptsStack.invoke( ingredient, input ).equals( true ) )
+						{
+							continue itemLoop;
+						}
+					}
+					return false;
+				}
+				fluidLoop:
+				for( FluidStack input : fluidInputs )
+				{
+					for( Object fluidIngredient : recipe.getFluidInputs() )
+					{
+						if( acceptsFluid.invoke( fluidIngredient, input ).equals( true ) )
+						{
+							continue fluidLoop;
+						}
+					}
+					return false;
+				}
+				return true;
+			}
+			catch( InvocationTargetException | IllegalAccessException e )
+			{
+				throw new RuntimeException( e );
+			}
+		}
 	}
 	
 	private static boolean isPlateRecipe(ProcessorRecipe recipe) {
@@ -337,8 +443,8 @@ public class GTCERecipeHelper {
 	}
 
 	@Optional.Method(modid = "gregtech")
-	private static RecipeMap<?> getExtractorMap(int gtVersion) {
-		if (gtVersion == 2) {
+	private static RecipeMap<?> getExtractorMap(boolean isCEu) {
+		if (isCEu) {
 			return RecipeMaps.EXTRACTOR_RECIPES;
 		} else {
 			try {


### PR DESCRIPTION
GTCEu recipe lookup changes in GTCEu 2.4 (upcoming) removed the CountableIngredient internal class used by the GTCERecipeHelper to determine recipe duplicates on NuclearCraft side.
This fixes a crash due to the missing class while allowing the integration to occur.