### PR TITLE
fix GrS integration with fluid machines (WARNING below)

### DIFF
--- a/src/main/java/nc/integration/groovyscript/GSBasicRecipeRegistry.java
+++ b/src/main/java/nc/integration/groovyscript/GSBasicRecipeRegistry.java
@@ -35,6 +35,12 @@ public abstract class GSBasicRecipeRegistry extends VirtualizedRegistry<BasicRec
 		restoreFromBackup().forEach(recipeHandler::addRecipe);
 		recipeHandler.onReload();
 	}
+
+	@GroovyBlacklist
+	@Override
+	public void afterScriptLoad() {
+		getRecipeHandler().postInit();
+	}
 	
 	@GroovyBlacklist
 	protected void addRecipeInternal(Object... objects) {

--- a/src/main/java/nc/recipe/BasicRecipeHandler.java
+++ b/src/main/java/nc/recipe/BasicRecipeHandler.java
@@ -345,7 +345,7 @@ public abstract class BasicRecipeHandler extends AbstractRecipeHandler<BasicReci
 	
 	protected void setValidFluids() {
 		if (validFluids == null) {
-			validFluids = new ArrayList();
+			validFluids = new ArrayList<>();
 		}
 		validFluids.clear();
 		validFluids.addAll(RecipeHelper.validFluids(this));

--- a/src/main/java/nc/recipe/BasicRecipeHandler.java
+++ b/src/main/java/nc/recipe/BasicRecipeHandler.java
@@ -344,7 +344,11 @@ public abstract class BasicRecipeHandler extends AbstractRecipeHandler<BasicReci
 	}
 	
 	protected void setValidFluids() {
-		validFluids = RecipeHelper.validFluids(this);
+		if (validFluids == null) {
+			validFluids = new ArrayList();
+		}
+		validFluids.clear();
+		validFluids.addAll(RecipeHelper.validFluids(this));
 	}
 	
 	public void postInit() {


### PR DESCRIPTION
Warning: I did not test whether the repo still compiles and such because the repo just wouldn't compile for me due to missing classes

This PR fixes the issue where adding a new input fluid to a machine such as Fluid Enricher through a Groovyscript recipe does not allow that fluid to enter the machine ([This script](https://github.com/TeamDimensional/Dimension-Gateway/blob/master/groovy/postInit/progression/chemistry.groovy#L5) is an example of what I mean)

[This mixin in my mod](https://github.com/TeamDimensional/GatewayCore/commit/bbdc257efb7440629b51aefc8d706d1c8ea340a3) fixes the issue so I just copied the fix in. Again didn't actually test it in this environment. Sorry 🥺 