### PR TITLE
fixed loot generating in chests

### DIFF
--- a/src/main/java/nc/radiation/RadiationHelper.java
+++ b/src/main/java/nc/radiation/RadiationHelper.java
@@ -25,6 +25,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.storage.loot.ILootContainer;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.*;
@@ -160,7 +161,7 @@ public class RadiationHelper {
 		
 		if (radiation_hardcore_containers > 0D) {
 			IItemHandler inventory = getTileInventory(provider, side);
-			if (inventory != null) {
+			if (inventory != null && !(tile instanceof ILootContainer && ((ILootContainer) tile).getLootTable() != null)) {
 				for (int i = 0; i < inventory.getSlots(); ++i) {
 					ItemStack stack = inventory.getStackInSlot(i);
 					rawRadiation += getRadiationFromStack(stack, radiation_hardcore_containers);


### PR DESCRIPTION
if chest contents can irradiate chunks, not yet generated loot will be generated by the algorithm checking for irradiated items. this interferes with luck-based loot table mechanisms.

a more thorough fix would be checking for avg radiation of items in the loot table but i feel like this is fine