### PR TITLE
Fix incompatibility with Bubbles

### DIFF
--- a/src/main/java/nc/radiation/RadiationHelper.java
+++ b/src/main/java/nc/radiation/RadiationHelper.java
@@ -1,6 +1,5 @@
 package nc.radiation;
 
-import baubles.api.BaubleType;
 import baubles.api.cap.*;
 import ic2.api.reactor.IReactor;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
@@ -461,8 +460,8 @@ public class RadiationHelper {
 				return false;
 			}
 			
-			for (int slot : BaubleType.TRINKET.getValidSlots()) {
-				if (baublesHandler.getStackInSlot(slot).isItemEqual(geiger_counter)) {
+			for (int i = 0; baublesHandler.getSlots(); ++i) {
+				if (baublesHandler.getStackInSlot(i).isItemEqual(geiger_counter)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
This PR changes BaubleType.TRINKET.getValidSlots() loop to baublesHandler.getSlots() loop. This fixes issues with [Bubbles](https://www.curseforge.com/minecraft/mc-mods/bubbles-a-baubles-fork).
This change doesn't affect anything besides compatibility with Bubbles. Original Baubles should still work and it should still perform the same way.
Be sure to test this PR.